### PR TITLE
fix(android): handle cancelled media capture intent (#291)

### DIFF
--- a/src/android/Capture.java
+++ b/src/android/Capture.java
@@ -332,8 +332,8 @@ public class Capture extends CordovaPlugin {
     public void onActivityResult(int requestCode, int resultCode, final Intent intent) {
         final Request req = pendingRequests.get(requestCode);
 
-        // Result received okay
-        if (resultCode == Activity.RESULT_OK) {
+        // Result received okay or the capture image intent has been cancelled
+        if (resultCode == Activity.RESULT_OK || (req.action == CAPTURE_IMAGE && intent == null)) {
             Runnable processActivityResult = new Runnable() {
                 @Override
                 public void run() {
@@ -416,6 +416,17 @@ public class Capture extends CordovaPlugin {
         JSONObject mediaFile = createMediaFile(data);
         if (mediaFile == null) {
             pendingRequests.resolveWithFailure(req, createErrorObject(CAPTURE_INTERNAL_ERR, "Error: no mediaFile created from " + data));
+            return;
+        }
+
+        long size = 0;
+        try {
+            size = mediaFile.getLong("size");
+        } catch (JSONException e) {
+            // noop
+        }
+        if (size == 0) {
+            pendingRequests.resolveWithFailure(req, createErrorObject(CAPTURE_NO_MEDIA_FILES, "Error: file is empty"));
             return;
         }
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
